### PR TITLE
Inject @import statement into first file, which is primary

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -15,7 +15,7 @@ function createBlessedFileName(filenameWithoutExtension, index) {
  * Inject @import rules into a .css file for all others
  */
 function addImports(parsedData, filenameWithoutExtension) {
-  const sourceToInjectIndex = parsedData.data.length - 1;
+  const sourceToInjectIndex = 0;
   let addImports = '';
 
   parsedData.data.map((fileContents, index) => { // eslint-disable-line max-nested-callbacks

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -7,20 +7,21 @@ const RawSource = webpackSources.RawSource;
 const SourceMapSource = webpackSources.SourceMapSource;
 const CSS_REGEXP = /\.css$/;
 
-function createBlessedFileName(filenameWithoutExtension, index) {
-  return index === 0 ? `${filenameWithoutExtension}.css` : `${filenameWithoutExtension}-blessed${index}.css`;
+function createBlessedFileName(filenameWithoutExtension, index, numFiles) {
+  return index === numFiles - 1 ? `${filenameWithoutExtension}.css` : `${filenameWithoutExtension}-blessed${index}.css`;
 }
 
 /**
  * Inject @import rules into a .css file for all others
  */
 function addImports(parsedData, filenameWithoutExtension) {
-  const sourceToInjectIndex = 0;
+  let numFiles = parsedData.data.length;
+  const sourceToInjectIndex = numFiles - 1;
   let addImports = '';
 
   parsedData.data.map((fileContents, index) => { // eslint-disable-line max-nested-callbacks
     if (index !== sourceToInjectIndex) {
-      const filename = createBlessedFileName(filenameWithoutExtension, index);
+      const filename = createBlessedFileName(filenameWithoutExtension, index, numFiles);
       // E.g. @import url(app-blessed1.css);
       addImports += `@import url(${filename});\n`;
     }
@@ -76,8 +77,9 @@ class BlessCSSWebpackPlugin {
                   parsedData = addImports(parsedData, filenameWithoutExtension);
                 }
 
+                let numFiles = parsedData.data.length;
                 parsedData.data.forEach((fileContents, index) => { // eslint-disable-line max-nested-callbacks
-                  const filename = createBlessedFileName(filenameWithoutExtension, index);
+                  const filename = createBlessedFileName(filenameWithoutExtension, index, numFiles);
                   const outputSourceMap = parsedData.maps[index];
 
                   if (outputSourceMap) {
@@ -86,14 +88,10 @@ class BlessCSSWebpackPlugin {
                     compilation.assets[filename] = new RawSource(fileContents);
                   }
 
-                  if ((index > 0 && !this.options.addImports) || (index === parsedData.data.length - 1 && this.options.addImports)) {
+                  if (index < numFiles - 1 && !this.options.addImports) {
                     chunk.files.push(filename);
                   }
                 });
-
-                if (this.options.addImports) {
-                  chunk.files = chunk.files.filter(file => file !== cssFileName); // eslint-disable-line max-nested-callbacks
-                }
               }
             });
         });


### PR DESCRIPTION
In my build process, the `@import` statements for the generated css files were being added to the last, generated css file, which in my build was the `styles-blessed1.css` file, rather than the primary `styles.css` file. It looks to me like this is a bug, as I was able to achieve the desired behaviour (adding the `@import` statements to `styles.css`) by modifying `sourceToInjectIndex` in `plugin.js`.

I don't know whether this will have unintended side effects, but it's solved the issue for me, so hopefully it'll help others.

Thanks for contributing this plugin btw, it's been a great help.